### PR TITLE
Update logging, random housecleaning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,5 +7,8 @@ Metrics/LineLength:
 Style/Documentation:
     Enabled: false
 
+Style/RaiseArgs:
+    Enabled: false
+
 Style/SignalException:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,11 @@
-Documentation:
+Metrics/AbcSize:
+  Max: 20
+
+Metrics/LineLength:
+  Max: 140
+
+Style/Documentation:
     Enabled: false
 
-LineLength:
-  Max: 120
-
-AbcSize:
-  Max: 20
+Style/SignalException:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,6 @@ end
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
-task prep: ['spec', 'rubocop']
+task prep: %w(spec rubocop)
 
 task default: :spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,7 @@
 require 'bundler/gem_tasks'
+
+require 'rspec/core'
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec) do |spec|
+  spec.pattern = FileList['spec/**/*_spec.rb']
+end

--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,10 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
 end
+
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+
+task prep: ['spec', 'rubocop']
+
+task default: :spec

--- a/lib/pester.rb
+++ b/lib/pester.rb
@@ -1,8 +1,13 @@
 require 'pester/behaviors'
 require 'pester/behaviors/sleep'
+require 'pester/config'
 require 'pester/version'
 
 module Pester
+  def self.configure(&block)
+    Config.configure(&block)
+  end
+
   def self.retry(options = {}, &block)
     retry_action(options.merge(on_retry: ->(_, delay_interval) { sleep(delay_interval) }), &block)
   end
@@ -73,22 +78,7 @@ module Pester
     end
   end
 
-  class << self
-    attr_accessor :logger
-  end
-
   private
-
-  def self.logger
-    @logger ||= begin
-      if defined? Rails
-        Rails.logger
-      else
-        require 'logger' unless defined? Logger
-        @logger = Logger.new(STDOUT)
-      end
-    end
-  end
 
   def self.merge_defaults(opts)
     opts[:retry_error_classes]      = opts[:retry_error_classes] ? Array(opts[:retry_error_classes]) : nil
@@ -97,6 +87,6 @@ module Pester
     opts[:delay_interval]           ||= 30
     opts[:on_retry]                 ||= ->(_, _) {}
     opts[:on_max_attempts_exceeded] ||= Behaviors::WarnAndReraise
-    opts[:logger]                   ||= logger
+    opts[:logger]                   ||= Config.logger
   end
 end

--- a/lib/pester.rb
+++ b/lib/pester.rb
@@ -73,14 +73,20 @@ module Pester
     end
   end
 
+  class << self
+    attr_accessor :logger
+  end
+
   private
 
   def self.logger
-    if defined? Rails
-      Rails.logger
-    else
-      require 'logger'
-      @logger ||= Logger.new(STDOUT)
+    @logger ||= begin
+      if defined? Rails
+        Rails.logger
+      else
+        require 'logger' unless defined? Logger
+        @logger = Logger.new(STDOUT)
+      end
     end
   end
 

--- a/lib/pester/config.rb
+++ b/lib/pester/config.rb
@@ -1,0 +1,16 @@
+module Pester
+  class Config
+    class << self
+      attr_writer :logger
+
+      def configure
+        yield self
+      end
+
+      def logger
+        require 'logger' unless defined? Logger
+        @logger ||= Logger.new(STDOUT)
+      end
+    end
+  end
+end

--- a/spec/helpers/scripted_failer.rb
+++ b/spec/helpers/scripted_failer.rb
@@ -10,7 +10,7 @@ class ScriptedFailer
   def fail(error_class, msg)
     if @fails > 0
       @fails -= 1
-      fail error_class, msg
+      raise error_class.new(msg)
     end
     @successes += 1
     @result

--- a/spec/pester_spec.rb
+++ b/spec/pester_spec.rb
@@ -179,3 +179,5 @@ describe 'retry_action' do
     end
   end
 end
+
+

--- a/spec/pester_spec.rb
+++ b/spec/pester_spec.rb
@@ -1,3 +1,4 @@
+require 'logger'
 require 'spec_helper'
 
 class MatchedError < RuntimeError; end
@@ -176,6 +177,28 @@ describe 'retry_action' do
 
         it_has_behavior 'raises an error only in the correct cases with a reraise class'
       end
+    end
+  end
+end
+
+describe 'logger' do
+  context 'when not otherwise configured' do
+    it 'defaults to the ruby logger' do
+      Pester.configure do |config|
+        config.logger = nil
+      end
+      expect(Pester::Config.logger).to_not be_nil
+      expect(Pester::Config.logger).to be_kind_of(Logger)
+    end
+  end
+
+  context 'when configured to use a particular class' do
+    it 'users that class' do
+      Pester.configure do |config|
+        config.logger = NullLogger.new
+      end
+      expect(Pester::Config.logger).to_not be_nil
+      expect(Pester::Config.logger).to be_kind_of(NullLogger)
     end
   end
 end

--- a/spec/pester_spec.rb
+++ b/spec/pester_spec.rb
@@ -179,5 +179,3 @@ describe 'retry_action' do
     end
   end
 end
-
-


### PR DESCRIPTION
Made some heavy changes here, including upping my rake game.

`rake spec` obv runs specs
`rake prep` runs specs, then rubocop

This PR makes logging one-time configurable for the whole class, which needs to be fleshed out further later on. The idea is that you can do this one time in your initializer

```
Pester.configure do |config|
  config.logger = NullLogger.new
end
```

and set the default logging (and in the future, the other options) in your app initializer, while still allowing you to override it on each call if you need.
