### PR TITLE
Expand retry options

### DIFF
--- a/lib/pester.rb
+++ b/lib/pester.rb
@@ -66,6 +66,7 @@ module Pester
           opts[:logger].warn("Failure encountered: #{e}, backing off and trying again #{attempts_left} more times. Trace: #{trace}")
           opts[:on_retry].call(attempt_num, opts[:delay_interval])
         else
+          # Careful here because you will get back the return value of the on_max_attempts_exceeded proc!
           return opts[:on_max_attempts_exceeded].call(opts[:logger], opts[:max_attempts], e)
         end
       end

--- a/lib/pester.rb
+++ b/lib/pester.rb
@@ -29,7 +29,7 @@ module Pester
   #   retry_error_messages      - A single or array of exception messages to retry on.  If only this options is passed,
   #                               any exception with a message containing one of these strings will be retried.  If this
   #                               option is passed along with retry_error_classes, retry will only happen when both the
-  #                               class and the message match the exception.
+  #                               class and the message match the exception.  Strings and regexes are both permitted.
   #   reraise_error_classes     - A single or array of exceptions to always re-raiseon. Thrown exceptions not in
   #                               this list (including parent/sub-classes) will be retried
   #   max_attempts              - Max number of attempts to retry
@@ -37,8 +37,6 @@ module Pester
   #                               passed to retry_with_backoff will retry first after 2 seconds, then 4, then 6, et al.
   #   on_retry                  - A Proc to be called on each successive failure, before the next retry
   #   on_max_attempts_exceeded  - A Proc to be called when attempt_num >= max_attempts - 1
-  #   message                   - String or regex to look for in thrown exception messages. Matches will trigger retry
-  #                               logic, non-matches will cause the exception to be reraised
   #
   # Usage:
   #   retry_action(retry_error_classes: [Mysql2::Error]) do

--- a/lib/pester.rb
+++ b/lib/pester.rb
@@ -56,7 +56,7 @@ module Pester
         return yield(block)
       rescue => e
         unless should_retry?(e, opts)
-          opts[:logger].warn("Reraising exception from inside retry_action.")
+          opts[:logger].warn('Reraising exception from inside retry_action.')
           raise
         end
 

--- a/lib/pester.rb
+++ b/lib/pester.rb
@@ -37,6 +37,7 @@ module Pester
   #                               passed to retry_with_backoff will retry first after 2 seconds, then 4, then 6, et al.
   #   on_retry                  - A Proc to be called on each successive failure, before the next retry
   #   on_max_attempts_exceeded  - A Proc to be called when attempt_num >= max_attempts - 1
+  #   logger                    - Where to log the output
   #
   # Usage:
   #   retry_action(retry_error_classes: [Mysql2::Error]) do

--- a/lib/pester.rb
+++ b/lib/pester.rb
@@ -67,7 +67,7 @@ module Pester
 
         retry_decision = class_retry || message_retry || (!retry_error_messages && !retry_error_classes)
 
-        if reraise_error || !(retry_decision)
+        if reraise_error || !retry_decision
           match_type = class_retry ? 'class' : 'message'
           opts[:logger].warn("Reraising exception from inside retry_action because provided #{match_type} was not matched.")
           raise

--- a/lib/pester.rb
+++ b/lib/pester.rb
@@ -55,7 +55,7 @@ module Pester
       begin
         return yield(block)
       rescue => e
-        if !should_retry?(e, opts)
+        unless should_retry?(e, opts)
           opts[:logger].warn("Reraising exception from inside retry_action.")
           raise
         end

--- a/lib/pester.rb
+++ b/lib/pester.rb
@@ -84,7 +84,7 @@ module Pester
           opts[:logger].warn("Failure encountered: #{e}, backing off and trying again #{attempts_left} more times. Trace: #{trace}")
           opts[:on_retry].call(attempt_num, opts[:delay_interval])
         else
-          opts[:on_max_attempts_exceeded].call(opts[:logger], opts[:max_attempts], e)
+          return opts[:on_max_attempts_exceeded].call(opts[:logger], opts[:max_attempts], e)
         end
       end
     end

--- a/lib/pester.rb
+++ b/lib/pester.rb
@@ -53,8 +53,7 @@ module Pester
 
     opts[:max_attempts].times do |attempt_num|
       begin
-        result = yield block
-        return result
+        return yield(block)
       rescue => e
         retry_error_classes = opts[:retry_error_classes]
         retry_error_messages = opts[:retry_error_messages]

--- a/lib/pester/version.rb
+++ b/lib/pester/version.rb
@@ -1,3 +1,3 @@
 module Pester
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/pester_spec.rb
+++ b/spec/pester_spec.rb
@@ -117,7 +117,7 @@ describe 'retry_action' do
       end
 
       context 'which does not do anything' do
-        let(:proc_to_call) { Proc.new {} }
+        let(:proc_to_call) { proc {} }
         it_has_behavior "doesn't raise an error"
       end
 
@@ -128,7 +128,7 @@ describe 'retry_action' do
 
       context 'which returns a value' do
         let(:return_value) { 'return_value' }
-        let(:proc_to_call) { Proc.new { return_value } }
+        let(:proc_to_call) { proc { return_value } }
         it_has_behavior "doesn't raise an error"
 
         it 'should return the result of the proc' do

--- a/spec/pester_spec.rb
+++ b/spec/pester_spec.rb
@@ -107,18 +107,37 @@ describe 'retry_action' do
       it_has_behavior 'raises an error'
     end
 
-    context 'with on_max_attempts_exceeded specified (which does not raise)' do
-      let(:do_nothing_proc) { proc {} }
+    context 'with on_max_attempts_exceeded proc specified' do
       let(:options) do
         {
           max_attempts: max_attempts,
-          on_max_attempts_exceeded: do_nothing_proc,
+          on_max_attempts_exceeded: proc_to_call,
           logger: null_logger
         }
       end
 
-      it_has_behavior "doesn't raise an error"
+      context 'which does not do anything' do
+        let(:proc_to_call) { proc {} }
+
+      end
+
+      context 'which reraises' do
+        let(:proc_to_call) { Behaviors::WarnAndReraise }
+        it_has_behavior 'raises an error'
+      end
+
+      context 'which returns a value' do
+        let(:return_value) { 'return_value' }
+        let(:proc_to_call) { Proc.new { return_value } }
+        it_has_behavior "doesn't raise an error"
+
+        it 'should return the result of the proc' do
+          expect { Pester.retry_action(options) { action } }.to eq(return_value)
+        end
+      end
     end
+
+    context 'with'
   end
 
   context 'for retry_action calls with provided retry classes and message strings' do

--- a/spec/pester_spec.rb
+++ b/spec/pester_spec.rb
@@ -117,8 +117,8 @@ describe 'retry_action' do
       end
 
       context 'which does not do anything' do
-        let(:proc_to_call) { proc {} }
-
+        let(:proc_to_call) { Proc.new {} }
+        it_has_behavior "doesn't raise an error"
       end
 
       context 'which reraises' do
@@ -132,7 +132,7 @@ describe 'retry_action' do
         it_has_behavior "doesn't raise an error"
 
         it 'should return the result of the proc' do
-          expect { Pester.retry_action(options) { action } }.to eq(return_value)
+          expect(Pester.retry_action(options) { action }).to eq(return_value)
         end
       end
     end

--- a/spec/pester_spec.rb
+++ b/spec/pester_spec.rb
@@ -136,8 +136,6 @@ describe 'retry_action' do
         end
       end
     end
-
-    context 'with'
   end
 
   context 'for retry_action calls with provided retry classes and message strings' do

--- a/spec/pester_spec.rb
+++ b/spec/pester_spec.rb
@@ -55,7 +55,6 @@ shared_examples 'raises an error only in the correct cases with a retry class' d
     let(:actual_error_message) { matching_error_message }
 
     it_has_behavior "doesn't raise an error"
-
     it_has_behavior 'returns and succeeds'
   end
 end
@@ -66,7 +65,6 @@ shared_examples 'raises an error only in the correct cases with a reraise class'
     let(:actual_error_message) { non_matching_error_message }
 
     it_has_behavior "doesn't raise an error"
-
     it_has_behavior 'returns and succeeds'
   end
 
@@ -88,7 +86,6 @@ describe 'retry_action' do
     let(:options) { { delay_interval: 0, logger: null_logger } }
 
     it_has_behavior "doesn't raise an error"
-
     it_has_behavior 'returns and succeeds'
   end
 
@@ -97,7 +94,6 @@ describe 'retry_action' do
     let(:options) { { max_attempts: 3, logger: null_logger } }
 
     it_has_behavior "doesn't raise an error"
-
     it_has_behavior 'returns and succeeds'
   end
 
@@ -138,7 +134,7 @@ describe 'retry_action' do
       let(:options) do
         {
           retry_error_classes: expected_error_classes,
-          message: /^Lost connection to MySQL server/,
+          retry_error_messages: /^Lost connection to MySQL server/,
           max_attempts: 10,
           logger: null_logger
         }


### PR DESCRIPTION
@slpsys i am noticing that pester doesn't exactly match our use case for all the stuff currently retried in phorklift / DW - the main difference is that a lot of the retries want a match both on the class of the error AND on the message fragment
