### PR TITLE
Better specs for on_max_attempts_exceeded proc

### DIFF
--- a/lib/pester.rb
+++ b/lib/pester.rb
@@ -66,6 +66,7 @@ module Pester
           opts[:logger].warn("Failure encountered: #{e}, backing off and trying again #{attempts_left} more times. Trace: #{trace}")
           opts[:on_retry].call(attempt_num, opts[:delay_interval])
         else
+          # Careful here because you will get back the return value of the on_max_attempts_exceeded proc!
           return opts[:on_max_attempts_exceeded].call(opts[:logger], opts[:max_attempts], e)
         end
       end

--- a/spec/pester_spec.rb
+++ b/spec/pester_spec.rb
@@ -117,7 +117,7 @@ describe 'retry_action' do
       end
 
       context 'which does not do anything' do
-        let(:proc_to_call) { Proc.new {} }
+        let(:proc_to_call) { proc {} }
         it_has_behavior "doesn't raise an error"
       end
 
@@ -128,7 +128,7 @@ describe 'retry_action' do
 
       context 'which returns a value' do
         let(:return_value) { 'return_value' }
-        let(:proc_to_call) { Proc.new { return_value } }
+        let(:proc_to_call) { proc { return_value } }
         it_has_behavior "doesn't raise an error"
 
         it 'should return the result of the proc' do

--- a/spec/pester_spec.rb
+++ b/spec/pester_spec.rb
@@ -107,18 +107,37 @@ describe 'retry_action' do
       it_has_behavior 'raises an error'
     end
 
-    context 'with on_max_attempts_exceeded specified (which does not raise)' do
-      let(:do_nothing_proc) { proc {} }
+    context 'with on_max_attempts_exceeded proc specified' do
       let(:options) do
         {
           max_attempts: max_attempts,
-          on_max_attempts_exceeded: do_nothing_proc,
+          on_max_attempts_exceeded: proc_to_call,
           logger: null_logger
         }
       end
 
-      it_has_behavior "doesn't raise an error"
+      context 'which does not do anything' do
+        let(:proc_to_call) { proc {} }
+
+      end
+
+      context 'which reraises' do
+        let(:proc_to_call) { Behaviors::WarnAndReraise }
+        it_has_behavior 'raises an error'
+      end
+
+      context 'which returns a value' do
+        let(:return_value) { 'return_value' }
+        let(:proc_to_call) { Proc.new { return_value } }
+        it_has_behavior "doesn't raise an error"
+
+        it 'should return the result of the proc' do
+          expect { Pester.retry_action(options) { action } }.to eq(return_value)
+        end
+      end
     end
+
+    context 'with'
   end
 
   context 'for retry_action calls with provided retry classes and message strings' do

--- a/spec/pester_spec.rb
+++ b/spec/pester_spec.rb
@@ -117,8 +117,8 @@ describe 'retry_action' do
       end
 
       context 'which does not do anything' do
-        let(:proc_to_call) { proc {} }
-
+        let(:proc_to_call) { Proc.new {} }
+        it_has_behavior "doesn't raise an error"
       end
 
       context 'which reraises' do
@@ -132,7 +132,7 @@ describe 'retry_action' do
         it_has_behavior "doesn't raise an error"
 
         it 'should return the result of the proc' do
-          expect { Pester.retry_action(options) { action } }.to eq(return_value)
+          expect(Pester.retry_action(options) { action }).to eq(return_value)
         end
       end
     end

--- a/spec/pester_spec.rb
+++ b/spec/pester_spec.rb
@@ -136,8 +136,6 @@ describe 'retry_action' do
         end
       end
     end
-
-    context 'with'
   end
 
   context 'for retry_action calls with provided retry classes and message strings' do


### PR DESCRIPTION
@slpsys @dollschasingmen i added specs for this behavior but i'm honestly not sure we want to be able to return the result of some random proc (and not raise an exception) when everything fails max_attempts times?

right now the actual use cases always reraise, so it's cool, but the return statement is a little misleading then.
