### PR TITLE
Adding environments

### DIFF
--- a/lib/pester.rb
+++ b/lib/pester.rb
@@ -1,11 +1,15 @@
 require 'pester/behaviors'
 require 'pester/behaviors/sleep'
+require 'pester/environment'
 require 'pester/config'
 require 'pester/version'
 
 module Pester
   def self.configure(&block)
     Config.configure(&block)
+    unless Config.environments.nil?
+      self.environments = Config.environments.select { |_, e| e.is_a?(Hash)}.map { |e| Environment.new(e) }
+    end
   end
 
   def self.retry(options = {}, &block)
@@ -73,6 +77,10 @@ module Pester
     end
 
     nil
+  end
+
+  class << self
+    attr_accessor :environments
   end
 
   private

--- a/lib/pester.rb
+++ b/lib/pester.rb
@@ -8,7 +8,7 @@ module Pester
   def self.configure(&block)
     Config.configure(&block)
     unless Config.environments.nil?
-      self.environments = Config.environments.select { |_, e| e.is_a?(Hash)}.map { |e| Environment.new(e) }
+      self.environments = Hash[Config.environments.select { |_, e| e.is_a?(Hash)}.map { |k, e| [k.to_sym, Environment.new(e)] }]
     end
   end
 
@@ -79,6 +79,16 @@ module Pester
     nil
   end
 
+  def respond_to?(method_sym)
+    super || Config.environments.has_key?(method_sym)
+  end
+
+  def method_missing(method_sym)
+    if Config.environments.has_key?(method_sym)
+      Config.environments[method_sym]
+    end
+  end
+
   class << self
     attr_accessor :environments
   end
@@ -86,8 +96,8 @@ module Pester
   private
 
   def self.should_retry?(e, opts = {})
-    retry_error_classes = opts[:retry_error_classes]
-    retry_error_messages = opts[:retry_error_messages]
+    retry_error_classes   = opts[:retry_error_classes]
+    retry_error_messages  = opts[:retry_error_messages]
     reraise_error_classes = opts[:reraise_error_classes]
 
     if retry_error_classes

--- a/lib/pester/config.rb
+++ b/lib/pester/config.rb
@@ -1,10 +1,15 @@
 module Pester
   class Config
     class << self
+      attr_reader :environments
       attr_writer :logger
 
       def configure
         yield self
+      end
+
+      def environments
+        @environments ||= {}
       end
 
       def logger

--- a/lib/pester/environment.rb
+++ b/lib/pester/environment.rb
@@ -1,6 +1,17 @@
 module Pester
   class Environment
-    def initialize(h)
+    attr_accessor :options
+
+    def initialize(opts)
+      @options = opts
+    end
+
+    def method_missing(name, *args, &block)
+      if name.to_s.start_with?('retry') && args.empty?
+        Pester.send(name, @options, &block)
+      else
+        super
+      end
     end
   end
 end

--- a/lib/pester/environment.rb
+++ b/lib/pester/environment.rb
@@ -1,0 +1,6 @@
+module Pester
+  class Environment
+    def initialize(h)
+    end
+  end
+end

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe Pester::Environment do
+  let(:options) { {} }
+  let!(:environment) { Pester::Environment.new(options) }
+
+  describe 'Delegation to Pester' do
+    context 'for retry-prefixed methods' do
+      context 'which are supported' do
+        let(:pester) { class_double("Pester").as_stubbed_const }
+
+        context 'without options' do
+          it 'calls Pester#retry without options' do
+            expect(pester).to receive(:send).with(:retry, {})
+            environment.retry { }
+          end
+        end
+        context 'with options' do
+          let(:options) { { test_opt: 1234 } }
+
+          it 'calls Pester#retry with the given options' do
+            expect(pester).to receive(:send).with(:retry, options)
+            environment.retry { }
+          end
+        end
+      end
+
+      context 'which do not exist' do
+        let(:options) { { test_opt: 1234 } }
+
+        it 'lets Pester raise NoMethodError' do
+          expect { environment.retry_does_not_exist { } }.to raise_error(NoMethodError)
+        end
+      end
+    end
+
+    context 'for non-retry-prefixed methods' do
+      let(:pester) { class_double("Pester").as_stubbed_const }
+
+      it 'raises NoMethodError' do
+        expect { environment.something_else { } }.to raise_error(NoMethodError)
+      end
+    end
+  end
+end

--- a/spec/pester_spec.rb
+++ b/spec/pester_spec.rb
@@ -87,7 +87,7 @@ shared_examples 'raises an error only in the correct cases with a reraise class'
   end
 end
 
-describe 'retry_action' do
+describe '#retry_action' do
   let(:intended_result) { 1000 }
   let(:action) { failer.fail(UnmatchedError, 'Dying') }
   let(:null_logger) { NullLogger.new }
@@ -258,7 +258,9 @@ describe 'retry_action' do
   end
 end
 
-describe 'environments' do
+describe '#environments' do
+  before { Pester.environments = {} }
+
   context 'when a non-hash environment is configured' do
     it 'does not add it to the Pester environment list' do
       Pester.configure do |config|
@@ -280,7 +282,7 @@ describe 'environments' do
   end
 end
 
-describe 'logger' do
+describe '#logger' do
   context 'when not otherwise configured' do
     it 'defaults to the ruby logger' do
       Pester.configure do |config|

--- a/spec/pester_spec.rb
+++ b/spec/pester_spec.rb
@@ -272,12 +272,24 @@ describe '#environments' do
   end
 
   context 'when a non-hash environment is configured' do
-    it 'does not add it to the Pester environment list' do
+    let(:environment_name) { :abc }
+    let(:options) { { option: 1234 } }
+
+    it 'adds it to the Pester environment list' do
       Pester.configure do |config|
-        config.environments[:abc] = { option: 1234 }
+        config.environments[environment_name] = options
       end
 
       expect(Pester.environments.count).to eq(1)
+    end
+
+    it 'contains an Environment with the appropriate options' do
+      Pester.configure do |config|
+        config.environments[environment_name] = options
+      end
+
+      expect(Pester.environments[environment_name].class).to eq(Pester::Environment)
+      expect(Pester.environments[environment_name].options).to eq(options)
     end
   end
 end

--- a/spec/pester_spec.rb
+++ b/spec/pester_spec.rb
@@ -258,6 +258,28 @@ describe 'retry_action' do
   end
 end
 
+describe 'environments' do
+  context 'when a non-hash environment is configured' do
+    it 'does not add it to the Pester environment list' do
+      Pester.configure do |config|
+        config.environments[:abc] = 1234
+      end
+
+      expect(Pester.environments.count).to eq(0)
+    end
+  end
+
+  context 'when a non-hash environment is configured' do
+    it 'does not add it to the Pester environment list' do
+      Pester.configure do |config|
+        config.environments[:abc] = { option: 1234 }
+      end
+
+      expect(Pester.environments.count).to eq(1)
+    end
+  end
+end
+
 describe 'logger' do
   context 'when not otherwise configured' do
     it 'defaults to the ruby logger' do


### PR DESCRIPTION
This works like in the Jira ticket:

```
# initializer
Pester.configure do |c| 
  c.environment[:aws] = { 'whatever' => 'ok' }
end
```

sets up an `Environment` object with some config options, and:

```
# app
class Thing 
  Pester.aws.retry do 
    something_faily
  end
end
```

`Pester.aws` returns the `:aws` `Environment` object, which acts as a proxy back to `Pester#retry_whatever`, injecting the environment options along the way. Kinda wonky in implementation I guess, but I like the abstraction it provides.

@apurvis @dollschasingmen 
