### PR TITLE
Refactor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,14 +1,29 @@
 Metrics/AbcSize:
-  Max: 20
+  Max: 27
+
+Metrics/CyclomaticComplexity:
+  Max: 7
 
 Metrics/LineLength:
   Max: 140
 
+Metrics/MethodLength:
+  Max: 23
+
+Metrics/PerceivedComplexity:
+  Max: 9
+
 Style/Documentation:
-    Enabled: false
+  Enabled: false
+
+Style/ModuleFunction:
+  Enabled: false
 
 Style/RaiseArgs:
-    Enabled: false
+  Enabled: false
+
+Style/SpaceAroundOperators:
+  Enabled: false
 
 Style/SignalException:
   Enabled: false

--- a/lib/pester.rb
+++ b/lib/pester.rb
@@ -10,10 +10,11 @@ module Pester
 
   def configure(&block)
     Config.configure(&block)
-    unless Config.environments.nil?
-      valid_environments = Config.environments.select { |_, e| e.is_a?(Hash) }
-      @environments = Hash[valid_environments.map { |k, e| [k.to_sym, Environment.new(e)] }]
-    end
+
+    return if Config.environments.nil?
+
+    valid_environments = Config.environments.select { |_, e| e.is_a?(Hash) }
+    @environments = Hash[valid_environments.map { |k, e| [k.to_sym, Environment.new(e)] }]
   end
 
   def retry_constant(options = {}, &block)

--- a/lib/pester.rb
+++ b/lib/pester.rb
@@ -5,22 +5,26 @@ require 'pester/config'
 require 'pester/version'
 
 module Pester
-  def self.configure(&block)
+  extend self
+  attr_accessor :environments
+
+  def configure(&block)
     Config.configure(&block)
     unless Config.environments.nil?
-      self.environments = Hash[Config.environments.select { |_, e| e.is_a?(Hash) }.map { |k, e| [k.to_sym, Environment.new(e)] }]
+      valid_environments = Config.environments.select { |_, e| e.is_a?(Hash) }
+      @environments = Hash[valid_environments.map { |k, e| [k.to_sym, Environment.new(e)] }]
     end
   end
 
-  def self.retry(options = {}, &block)
+  def retry_constant(options = {}, &block)
     retry_action(options.merge(on_retry: Behaviors::Sleep::Constant), &block)
   end
 
-  def self.retry_with_backoff(options = {}, &block)
+  def retry_with_backoff(options = {}, &block)
     retry_action(options.merge(on_retry: Behaviors::Sleep::Linear), &block)
   end
 
-  def self.retry_with_exponential_backoff(options = {}, &block)
+  def retry_with_exponential_backoff(options = {}, &block)
     retry_action({ delay_interval: 1 }.merge(options).merge(on_retry: Behaviors::Sleep::Exponential), &block)
   end
 
@@ -49,7 +53,7 @@ module Pester
   #     FileUtils.rm_r(directory)
   #   end
 
-  def self.retry_action(opts = {}, &block)
+  def retry_action(opts = {}, &block)
     merge_defaults(opts)
     if opts[:retry_error_classes] && opts[:reraise_error_classes]
       fail 'You can only have one of retry_error_classes or reraise_error_classes'
@@ -79,25 +83,21 @@ module Pester
     nil
   end
 
-  def respond_to?(method_sym)
+  def respond_to?(method_sym, options = {}, &block)
     super || Config.environments.key?(method_sym)
   end
 
-  def method_missing(method_sym)
-    if Config.environments.key?(method_sym)
-      Config.environments[method_sym]
+  def method_missing(method_sym, options = {}, &block)
+    if @environments.key?(method_sym)
+      @environments[method_sym]
     else
       super
     end
   end
 
-  class << self
-    attr_accessor :environments
-  end
-
   private
 
-  def self.should_retry?(e, opts = {})
+  def should_retry?(e, opts = {})
     retry_error_classes   = opts[:retry_error_classes]
     retry_error_messages  = opts[:retry_error_messages]
     reraise_error_classes = opts[:reraise_error_classes]
@@ -117,7 +117,7 @@ module Pester
     end
   end
 
-  def self.merge_defaults(opts)
+  def merge_defaults(opts)
     opts[:retry_error_classes]      = opts[:retry_error_classes] ? Array(opts[:retry_error_classes]) : nil
     opts[:retry_error_messages]     = opts[:retry_error_messages] ? Array(opts[:retry_error_messages]) : nil
     opts[:reraise_error_classes]    = opts[:reraise_error_classes] ? Array(opts[:reraise_error_classes]) : nil
@@ -127,4 +127,6 @@ module Pester
     opts[:on_max_attempts_exceeded] ||= Behaviors::WarnAndReraise
     opts[:logger]                   ||= Config.logger
   end
+
+  alias_method :retry, :retry_action
 end

--- a/lib/pester/version.rb
+++ b/lib/pester/version.rb
@@ -1,3 +1,3 @@
 module Pester
-  VERSION = '0.2.1'
+  VERSION = '1.0.0'
 end

--- a/lib/pester/version.rb
+++ b/lib/pester/version.rb
@@ -1,3 +1,3 @@
 module Pester
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/pester.gemspec
+++ b/pester.gemspec
@@ -10,9 +10,9 @@ Gem::Specification.new do |spec|
   spec.email         = ['marc@lumoslabs.com']
   spec.summary       = 'Common block-based retry for external calls.'
   spec.description   = <<-EOD
-                       |We found ourselves constantly wrapping network-facing calls with all kinds of bespoke,
-                       | copied, and rewritten retry logic. This gem is an attempt to unify common behaviors,
-                       | like simple retry, retry with linear backoff, and retry with exponential backoff.
+                       We found ourselves constantly wrapping network-facing calls with all kinds of bespoke,
+                       copied, and rewritten retry logic. This gem is an attempt to unify common behaviors,
+                       like simple retry, retry with linear backoff, and retry with exponential backoff.
 EOD
   spec.homepage      = 'https://github.com/lumoslabs/pester'
   spec.license       = 'MIT'

--- a/spec/pester_spec.rb
+++ b/spec/pester_spec.rb
@@ -275,19 +275,22 @@ describe '#environments' do
     let(:environment_name) { :abc }
     let(:options) { { option: 1234 } }
 
-    it 'adds it to the Pester environment list' do
+    before do
       Pester.configure do |config|
         config.environments[environment_name] = options
       end
+    end
 
+    it 'adds it to the Pester environment list' do
       expect(Pester.environments.count).to eq(1)
     end
 
     it 'contains an Environment with the appropriate options' do
-      Pester.configure do |config|
-        config.environments[environment_name] = options
-      end
+      expect(Pester.environments[environment_name].class).to eq(Pester::Environment)
+      expect(Pester.environments[environment_name].options).to eq(options)
+    end
 
+    it 'contains an Environment with the appropriate options' do
       expect(Pester.environments[environment_name].class).to eq(Pester::Environment)
       expect(Pester.environments[environment_name].options).to eq(options)
     end

--- a/spec/pester_spec.rb
+++ b/spec/pester_spec.rb
@@ -290,9 +290,9 @@ describe '#environments' do
       expect(Pester.environments[environment_name].options).to eq(options)
     end
 
-    it 'contains an Environment with the appropriate options' do
-      expect(Pester.environments[environment_name].class).to eq(Pester::Environment)
-      expect(Pester.environments[environment_name].options).to eq(options)
+    it 'contains an Environment addressable directly from Pester with the appropriate options' do
+      expect(Pester.send(environment_name).class).to eq(Pester::Environment)
+      expect(Pester.send(environment_name).options).to eq(options)
     end
   end
 end


### PR DESCRIPTION
Fixing an issue with environments, refactoring a bit, adding specs, and bumping to `1.0`, because I'm breaking `retry`. It used to be a synonym for constant retry intervals, but this was non-optimal for use with environments, because `Pester.aws.retry {}` (which seems straightforward) would always force constant, regardless of what you chose in the environment config. That's pretty dumb, so I'm renaming the old behavior `retry_constant`, and letting `retry` defer to your environment, which is IMO the way to go for config.

@apurvis @dtboctor 
